### PR TITLE
Enable parallel unit test execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -166,6 +166,23 @@ subprojects {
 
         // Ensure JaCoCo uses the same JDK as the test execution
         jvmArgs("-XX:+EnableDynamicAgentLoading")
+
+        // Run tests in parallel forks (JVM processes)
+        // Use half of available processors to balance CPU and memory usage
+        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+
+        // Enable JUnit 5 parallel execution within a fork by default
+        systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+        systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
+        systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
+        systemProperty("junit.jupiter.execution.parallel.config.strategy", "dynamic")
+
+        // For Spring module, disable JUnit parallelism to avoid context races
+        if (project.name == "jcachex-spring") {
+            systemProperty("junit.jupiter.execution.parallel.enabled", "false")
+            systemProperty("junit.jupiter.execution.parallel.mode.default", "same_thread")
+            systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "same_thread")
+        }
     }
 
     tasks.jacocoTestReport {
@@ -407,7 +424,7 @@ project(":jcachex-core") {
         implementation("org.slf4j:slf4j-api:1.7.36")
 
         // Testing
-        testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+        testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
         testImplementation("org.mockito:mockito-core:4.11.0") {
             // Force version to maintain Java 8 compatibility
             version {
@@ -436,7 +453,7 @@ project(":jcachex-kotlin") {
 
         // Testing
         testImplementation("org.jetbrains.kotlin:kotlin-test")
-        testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+        testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
         testImplementation("org.mockito:mockito-core:4.11.0") {
             version {
                 strictly("4.11.0")
@@ -464,7 +481,7 @@ project(":jcachex-spring") {
         implementation("org.springframework.boot:spring-boot-configuration-processor:2.7.18")
 
         // Testing
-        testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+        testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
         testImplementation("org.springframework.boot:spring-boot-starter-test:2.7.18")
         testImplementation("org.mockito:mockito-core:4.11.0") {
             version {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,14 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "JCacheX"
 
 include(


### PR DESCRIPTION
## Description
This PR significantly reduces unit test execution time by enabling parallel test execution at both the Gradle and JUnit 5 levels.

Key changes include:
*   **Gradle Parallel Forks:** Configured `maxParallelForks` to utilize half of the available CPU cores for parallel test execution across modules.
*   **JUnit 5 Parallelism:** Enabled JUnit 5's internal parallel execution for most modules.
*   **Spring Module Specifics:** Disabled JUnit 5's internal parallelism for the `jcachex-spring` module to prevent flakiness and context races, while still benefiting from Gradle's parallel forks.
*   **JUnit Upgrade:** Updated JUnit Jupiter to version 5.10.2.
*   **JDK Toolchain Provisioning:** Added the Foojay toolchain resolver to `settings.gradle.kts` to automatically provision the required JDK 11, improving build reliability.

These changes were thoroughly tested with multiple runs to ensure no flakiness was introduced.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔒 Security improvement

## Testing
- [x] Unit tests pass locally
- [ ] Integration tests pass locally
- [x] Manual testing completed
- [x] Test coverage maintained/improved

### Test Details
The full test suite was executed multiple times to verify stability and performance improvements.
```bash
./gradlew test
./gradlew detekt
./gradlew ktlintCheck
```

## Code Quality Checklist
- [x] Code follows project coding standards
- [x] Self-review of the code completed
- [x] Comments added in hard-to-understand areas
- [x] No new warnings introduced
- [ ] Documentation updated (if applicable)
- [x] No sensitive information exposed

## Coverage Impact
- [x] Coverage maintained or improved
- [x] New code is properly tested
- [x] Edge cases are covered

## Screenshots/Logs
<!-- Add screenshots or logs if applicable -->

<!--
Add screenshots here if UI changes are involved
Add logs here if debugging information is relevant
-->

## Related Issues
<!-- Link to related issues -->

Fixes #(issue_number)
Closes #(issue_number)
Related to #(issue_number)

## Dependencies
- [ ] No new dependencies added
- [x] New dependencies are necessary and approved (Foojay toolchain resolver plugin for Gradle)
- [x] Dependencies are up to date (JUnit Jupiter 5.10.2)

## Deployment Notes
- [ ] No deployment considerations
- [ ] Database migrations required
- [x] Configuration changes required (Gradle build and settings files)
- [ ] Breaking changes documented

## Reviewer Checklist
<!-- For reviewers -->

- [ ] Code review completed
- [ ] Tests are adequate
- [ ] Documentation is sufficient
- [ ] No security concerns
- [ ] Performance impact acceptable
- [ ] CI/CD pipeline passes

---

**Additional Notes:**
The initial attempt to enable full JUnit 5 parallelism across all modules led to flakiness in the `jcachex-spring` module due to Spring context management. This was resolved by disabling JUnit-level parallelism specifically for that module, while still leveraging Gradle's parallel forks for overall build speedup. The current configuration provides a significant performance gain without introducing instability.

---
<a href="https://cursor.com/background-agent?bcId=bc-35723112-b2e8-4f8b-a278-c346ac500ddd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35723112-b2e8-4f8b-a278-c346ac500ddd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

